### PR TITLE
Ability to restrict TLS version in Channel declaration

### DIFF
--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -95,7 +95,10 @@ Channel::ptr_t Channel::CreateSecureFromUri(const std::string &uri,
                                       const std::string &path_to_client_key,
                                       const std::string &path_to_client_cert,
                                       bool verify_hostname,
-                                      int frame_max)
+                                      int frame_max,
+                                      bool sslRestrict,
+                                      amqp_tls_version_t min,
+                                      amqp_tls_version_t max)
 {
     amqp_connection_info info;
     amqp_default_connection_info(&info);
@@ -118,7 +121,10 @@ Channel::ptr_t Channel::CreateSecureFromUri(const std::string &uri,
                       std::string(info.password),
                       std::string(info.vhost),
                       frame_max,
-                      verify_hostname);
+                      verify_hostname,
+                      sslRestrict,
+                      min,
+                      max);
     }
     else
     {
@@ -178,6 +184,9 @@ Channel::Channel(const std::string &host,
     if (NULL == socket)
     {
         throw std::bad_alloc();
+    }
+    if (ssl_params.sslRestrict) {
+        amqp_ssl_socket_set_ssl_versions(socket, ssl_params.sslMin, ssl_params.sslMax);
     }
     amqp_ssl_socket_set_verify(socket, ssl_params.verify_hostname);
 

--- a/src/SimpleAmqpClient/Channel.h
+++ b/src/SimpleAmqpClient/Channel.h
@@ -42,6 +42,7 @@
 #include <boost/make_shared.hpp>
 #include <string>
 #include <vector>
+#include <amqp_ssl_socket.h>
 
 #ifdef _MSC_VER
 # pragma warning ( push )
@@ -100,6 +101,9 @@ protected:
         std::string path_to_client_key;
         std::string path_to_client_cert;
         bool verify_hostname;
+        bool sslRestrict;
+        amqp_tls_version_t sslMin;
+        amqp_tls_version_t sslMax;
     };
 
 public:
@@ -120,6 +124,9 @@ public:
     * @param frame_max Request that the server limit the maximum size of any frame to this value
     * @param verify_host Verify the hostname against the certificate when
     * opening the SSL connection.
+    * @param sslRestrict Restrict tls versions
+    * @param min min version to restrict to
+    * @param max max version to restrict to
     *
     * @return a new Channel object pointer
     */
@@ -133,13 +140,19 @@ public:
                               const std::string &password = "guest",
                               const std::string &vhost = "/",
                               int frame_max = 131072,
-                              bool verify_hostname = true)
+                              bool verify_hostname = true,
+                              bool sslRestrict = false,
+                              amqp_tls_version_t min = AMQP_TLSv1,
+                              amqp_tls_version_t max = AMQP_TLSvLATEST)
     {
         SSLConnectionParams ssl_params;
         ssl_params.path_to_ca_cert = path_to_ca_cert;
         ssl_params.path_to_client_key = path_to_client_key;
         ssl_params.path_to_client_cert = path_to_client_cert;
         ssl_params.verify_hostname = verify_hostname;
+        ssl_params.sslRestrict = sslRestrict;
+        ssl_params.sslMin = min;
+        ssl_params.sslMax = max;
 
         return boost::make_shared<Channel>(host,
                                            port,
@@ -172,6 +185,9 @@ public:
      * @param verify_hostname Verify the hostname against the certificate when
      * opening the SSL connection.
      * * @param frame_max [in] requests that the broker limit the maximum size of any frame to this value
+     * @param sslRestrict Restrict tls versions
+     * @param min min version to restrict to
+     * @param max max version to restrict to
      * @returns a new Channel object
      */
     static ptr_t CreateSecureFromUri(const std::string &uri,
@@ -179,7 +195,10 @@ public:
                                const std::string &path_to_client_key="",
                                const std::string &path_to_client_cert="",
                                bool verify_hostname = true,
-                               int frame_max = 131072);
+                               int frame_max = 131072,
+                               bool sslRestrict = false,
+                               amqp_tls_version_t min = AMQP_TLSv1,
+                               amqp_tls_version_t max = AMQP_TLSvLATEST);
 
     explicit Channel(const std::string &host,
                      int port,


### PR DESCRIPTION
This patch allow to pass minimal and maximum version of tls used by rabbitmq-c for SSL socket.